### PR TITLE
Workaround for linker dependency issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ CLFAGS += $(FEATUREFLAGS)
 # https://github.com/vlfeat/vlfeat/issues/4
 # These error appear as a result of http://wiki.debian.org/ToolChain/DSOLinking that
 # was added between gcc4.4 and gcc4.6.1.
-CLFAGS += -Wl,--no-as-needed
+CFLAGS += -Wl,--no-as-needed
 CFLAGS += -std=c99
 CFLAGS += -Wall -Wextra
 CFLAGS += -Wno-unused-function -Wno-long-long -Wno-variadic-macros


### PR DESCRIPTION
This issue is described here https://github.com/vlfeat/vlfeat/issues/4
These errors appear as a result of http://wiki.debian.org/ToolChain/DSOLinking
that was added between gcc4.4 and gcc4.6.1.

By passing
CLFAGS += -Wl,--no-as-needed
to the linker, the error is resolved. However, this points to an
underlying problem with the dependency structure that should probably be fixed.
