### PR TITLE
add -pthread and -lm to BIN_{C,LD}FLAGS in make/bin.mak

### DIFF
--- a/make/bin.mak
+++ b/make/bin.mak
@@ -18,8 +18,8 @@ info: bin-info
 #                                                        Configuration
 # --------------------------------------------------------------------
 
-BIN_CFLAGS = $(STD_CFLAGS) -I$(VLDIR)
-BIN_LDFLAGS = $(STD_LDFLAGS) -L$(BINDIR) -lvl
+BIN_CFLAGS = $(STD_CFLAGS) -I$(VLDIR) -pthread
+BIN_LDFLAGS = $(STD_LDFLAGS) -L$(BINDIR) -lvl -lm
 
 # Mac OS X Intel 32
 ifeq ($(ARCH),maci)


### PR DESCRIPTION
When building on ArchLinux (GCC 4.6.2, binutils 2.22.0, libc 2.14.1) I hit a couple of linking errors when building the test programs.

Building `bin-all` target from a clean master checkout (ARCH=glnxa64), I get:

```
******* Offending Command:
cc '-std=c99' '-Wall' '-Wextra' '-Wno-unused-function' '-Wno-long-long' '-Wno-variadic-macros' '-DNDEBUG' '-O3' '-I.' 'src/test_threads.c' '-Wl,--rpath,$ORIGIN/' '-Wl,--as-needed' '-Lbin/glnxa64' '-lvl' '-Wl,--rpath,$ORIGIN/' '-o' 'bin/glnxa64/test_threads'
******* Error Code: 1
******* Command Output:
/usr/bin/ld: /tmp/ccdveHHR.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: note: 'pthread_create@@GLIBC_2.2.5' is defined in DSO /lib/libpthread.so.0 so try adding it to the linker command line
/lib/libpthread.so.0: could not read symbols: Invalid operation
collect2: ld returned 1 exit status
make: *** [bin/glnxa64/test_threads] Error 1
```

Adding `-pthread` to `BIN_CFLAGS` in make/bin.mak fixes this error and leads to:

```
******* Offending Command:
cc '-std=c99' '-Wall' '-Wextra' '-Wno-unused-function' '-Wno-long-long' '-Wno-variadic-macros' '-DNDEBUG' '-O3' '-I.' '-pthread' 'src/test_mathop.c' '-Wl,--rpath,$ORIGIN/' '-Wl,--as-needed' '-Lbin/glnxa64' '-lvl' '-Wl,--rpath,$ORIGIN/' '-o' 'bin/glnxa64/test_mathop'
******* Error Code: 1
******* Command Output:
/usr/bin/ld: /tmp/cch4oDaw.o: undefined reference to symbol 'sqrtf@@GLIBC_2.2.5'
/usr/bin/ld: note: 'sqrtf@@GLIBC_2.2.5' is defined in DSO /lib/libm.so.6 so try adding it to the linker command line
/lib/libm.so.6: could not read symbols: Invalid operation
collect2: ld returned 1 exit status
make: *** [bin/glnxa64/test_mathop] Error 1
```

Adding `-lm` to `BIN_LDFLAGS` in make/bin.mak fixes this.
