### PR TITLE
Added support for "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ SHELL = /bin/bash
 .PHONY : all
 all:
 
+# Pant-
+PREFIX			:= /usr
+PATH_INSTALL	:= $(PREFIX)/lib
+PATH_INCLUDE	:= $(PREFIX)/include
+
 # Feature selection
 DISABLE_SSE2=no
 DISABLE_THREADS=no
@@ -290,6 +295,8 @@ clean:
 archclean: clean
 
 distclean:
+
+install: dll-install
 
 info:
 	$(call echo-title,General settings)

--- a/make/dll.mak
+++ b/make/dll.mak
@@ -76,6 +76,13 @@ no_dep_targets += dll-info
 dll-all: dll
 dll: $(dll_tgt)
 
+dll-install:
+	install -m 644 $(dll_tgt) $(PATH_INSTALL)
+	test -d $(PATH_INCLUDE)/vl || mkdir $(PATH_INCLUDE)/vl
+	for FILE in $(wildcard vl/*.h); do \
+      cp "$$FILE" $(PATH_INCLUDE)/vl; \
+   done
+
 # generate the dll-dir target
 $(eval $(call gendir, dll, $(BINDIR) $(BINDIR)/objs))
 


### PR DESCRIPTION
One of the main issues I found with wanting to use vlfeat's C interface quickly is that it's not installable. That is there is no "install" target for make. I have added support for a pretty dumbed down version of an "install" target for make which should work on most distributions, that I think make the library more comfortable to use and would probably be a step forward in attracting maintainer interest for including the library into some linux distributions.
