### PR TITLE
Keep track of peak and edge scores of each SIFT keypoint.

### DIFF
--- a/src/sift.c
+++ b/src/sift.c
@@ -735,10 +735,12 @@ main(int argc, char **argv)
 
           if (out.active) {
             int l ;
-            vl_file_meta_put_double (&out, k -> x     ) ;
-            vl_file_meta_put_double (&out, k -> y     ) ;
-            vl_file_meta_put_double (&out, k -> sigma ) ;
-            vl_file_meta_put_double (&out, angles [q] ) ;
+            vl_file_meta_put_double (&out, k -> x          ) ;
+            vl_file_meta_put_double (&out, k -> y          ) ;
+            vl_file_meta_put_double (&out, k -> sigma      ) ;
+            vl_file_meta_put_double (&out, k -> peak_score ) ;
+            vl_file_meta_put_double (&out, k -> edge_score ) ;
+            vl_file_meta_put_double (&out, angles [q]      ) ;
             for (l = 0 ; l < 128 ; ++l) {
               vl_file_meta_put_uint8 (&out, (vl_uint8) (512.0 * descr [l])) ;
             }
@@ -746,10 +748,12 @@ main(int argc, char **argv)
           }
 
           if (frm.active) {
-            vl_file_meta_put_double (&frm, k -> x     ) ;
-            vl_file_meta_put_double (&frm, k -> y     ) ;
-            vl_file_meta_put_double (&frm, k -> sigma ) ;
-            vl_file_meta_put_double (&frm, angles [q] ) ;
+            vl_file_meta_put_double (&frm, k -> x          ) ;
+            vl_file_meta_put_double (&frm, k -> y          ) ;
+            vl_file_meta_put_double (&frm, k -> sigma      ) ;
+            vl_file_meta_put_double (&frm, k -> peak_score ) ;
+            vl_file_meta_put_double (&frm, k -> edge_score ) ;
+            vl_file_meta_put_double (&frm, angles [q]      ) ;
             if (frm.protocol == VL_PROT_ASCII) fprintf(frm.file, "\n") ;
           }
 

--- a/vl/sift.c
+++ b/vl/sift.c
@@ -1406,15 +1406,16 @@ vl_sift_detect (VlSiftFilt * f)
     {
       double val   = at(0,0,0)
         + 0.5 * (Dx * b[0] + Dy * b[1] + Ds * b[2]) ;
-      double score = (Dxx+Dyy)*(Dxx+Dyy) / (Dxx*Dyy - Dxy*Dxy) ;
+      double peak_score = vl_abs_d(val);
+      double edge_score = (Dxx+Dyy)*(Dxx+Dyy) / (Dxx*Dyy - Dxy*Dxy) ;
       double xn = x + b[0] ;
       double yn = y + b[1] ;
       double sn = s + b[2] ;
 
       vl_bool good =
-        vl_abs_d (val)  > tp                  &&
-        score           < (te+1)*(te+1)/te    &&
-        score           >= 0                  &&
+        peak_score      > tp                  &&
+        edge_score      < (te+1)*(te+1)/te    &&
+        edge_score      >= 0                  &&
         vl_abs_d (b[0]) <  1.5                &&
         vl_abs_d (b[1]) <  1.5                &&
         vl_abs_d (b[2]) <  1.5                &&
@@ -1426,14 +1427,16 @@ vl_sift_detect (VlSiftFilt * f)
         sn              <= s_max ;
 
       if (good) {
-        k-> o     = f->o_cur ;
-        k-> ix    = x ;
-        k-> iy    = y ;
-        k-> is    = s ;
-        k-> s     = sn ;
-        k-> x     = xn * xper ;
-        k-> y     = yn * xper ;
-        k-> sigma = f->sigma0 * pow (2.0, sn/f->S) * xper ;
+        k-> o          = f->o_cur ;
+        k-> ix         = x ;
+        k-> iy         = y ;
+        k-> is         = s ;
+        k-> s          = sn ;
+        k-> x          = xn * xper ;
+        k-> y          = yn * xper ;
+        k-> sigma      = f->sigma0 * pow (2.0, sn/f->S) * xper ;
+        k-> peak_score = peak_score;
+        k-> edge_score = edge_score;
         ++ k ;
       }
 

--- a/vl/sift.h
+++ b/vl/sift.h
@@ -39,6 +39,9 @@ typedef struct _VlSiftKeypoint
   float y ;     /**< y coordinate. */
   float s ;     /**< s coordinate. */
   float sigma ; /**< scale. */
+
+  float peak_score ; /**< peak score. */
+  float edge_score ; /**< edge score. */
 } VlSiftKeypoint ;
 
 /** ------------------------------------------------------------------


### PR DESCRIPTION
Peak and edge thresholds are useful to reduce the number of keypoints produced by the SIFT. Identifying the "right" thresholds for a given task, however, is not trivial.

I have found an alternative approach quite useful. Given the full list of keypoints, I sort it by peak / edge scores and keep only the highest ranked results. Unfortunately, the current vlfeat implementation does not expose such scores to the user. This commit changes that, extending the VlSiftKeypoint struct.
