### PR TITLE
Noticing users using VlKMeansANN that it is not implemented

### DIFF
--- a/vl/kmeans.c
+++ b/vl/kmeans.c
@@ -1277,6 +1277,8 @@ VL_XCAT(_vl_kmeans_refine_centers_, SFX)
       return
       VL_XCAT(_vl_kmeans_refine_centers_elkan_, SFX)(self, data, numData) ;
       break ;
+    case VlKMeansANN:
+      VL_PRINTF("ANN is not implemented yet, aborting!");
     default:
       abort() ;
   }


### PR DESCRIPTION
Add a notice stating that ANN is not yet implemented when one tries to use it before aborting.

It may help users thinking that the algorithm must implemented since the VlKMeansANN variable exists in the VlKMeansAlgorithm enum.
