### PR TITLE
In vl_lbp_process added a line to clean up the buffer on entering

### DIFF
--- a/vl/lbp.c
+++ b/vl/lbp.c
@@ -206,7 +206,7 @@ vl_lbp_process (VlLbp * self,
 
   /* clean the buffer features */
   {
-      memset(features, 0, sizeof(float)*cdimension);
+      memset(features, 0, sizeof(float)*cdimension*cstride);
   }
 
   /* accumulate pixel-level measurements into cells */


### PR DESCRIPTION
I ran into this, because vl_lbp_process assumes the output buffer are all zeros without documentation. I suggest to add one cleaning up there, it's hard to notice this, since this still gives you a normalized LBP histogram.
