### PR TITLE
allocated more memory than needed in vl_ubcmatch.c

### DIFF
--- a/toolbox/sift/vl_ubcmatch.c
+++ b/toolbox/sift/vl_ubcmatch.c
@@ -160,7 +160,7 @@ mexFunction(int nout, mxArray *out[],
   **                                                         Do the job
   ** --------------------------------------------------------------- */
   {
-    Pair* pairs_begin = (Pair*) mxMalloc(sizeof(Pair) * (K1+K2)) ;
+    Pair* pairs_begin = (Pair*) mxMalloc(sizeof(Pair) * (K1 > K2 ? K1 : K2)) ;
     Pair* pairs_iterator = pairs_begin ;
 
 


### PR DESCRIPTION
no need to allocate (K1 + K2) pairs. MAX(K1, K2) should be enough.
