### PR TITLE
phow_caltech101: pass the same arguments to vl_homkermap on train and te...

### DIFF
--- a/apps/phow_caltech101.m
+++ b/apps/phow_caltech101.m
@@ -314,7 +314,7 @@ function [className, score] = classify(model, im)
 % -------------------------------------------------------------------------
 
 hist = getImageDescriptor(model, im) ;
-psix = vl_homkermap(hist, 1, 'kchi2', 'period', .7) ;
+psix = vl_homkermap(hist, 1, 'kchi2', 'gamma', .5) ;
 scores = model.w' * psix + model.b' ;
 [score, best] = max(scores) ;
 className = model.classes{best} ;


### PR DESCRIPTION
The inconsistency introduced in commit 781319c2811929031ff451330b38b412cb73d914 leads too poor classification as soon as the `classify` function is used.
