### PR TITLE
update mser.c  fix the height of a tree

### DIFF
--- a/vl/mser.c
+++ b/vl/mser.c
@@ -555,10 +555,8 @@ vl_mser_process (VlMserFilt* f, vl_mser_pix const* im)
 
         vl_mser_pix nr_val = 0 ;
         vl_uint     nr_idx = 0 ;
-        int         hgt   = r [ r_idx] .height ;
-        int         n_hgt = r [nr_idx] .height ;
 
-        /*
+         /*
           Now we join the two subtrees rooted at
 
            R_IDX = ROOT(  IDX)
@@ -567,10 +565,13 @@ vl_mser_process (VlMserFilt* f, vl_mser_pix const* im)
           Note that R_IDX = ROOT(IDX) might change as we process more
           neighbors, so we need keep updating it.
         */
-
          r_idx = climb(r,   idx) ;
         nr_idx = climb(r, n_idx) ;
 
+        int         hgt   = r [ r_idx] .height ;
+        int         n_hgt = r [nr_idx] .height ;
+
+       
         /*
           At this point we have three possibilities:
 


### PR DESCRIPTION
hi sir:
when i debug the mser.c. i found the value of "n_hgt" and "hgt" is not always correct. then i found the code below in "mser.c":
vl_mser_pix nr_val = 0 ;
vl_uint     nr_idx = 0 ;
int         hgt   = r [ r_idx] .height ;
int         n_hgt = r [nr_idx] .height ;
r_idx = climb(r,   idx) ;
nr_idx = climb(r, n_idx) ;

 it means that the "n_hgt" is always the height of r[0]. because the "nr_idx" is "0"  when the computer runs the code "int   n_hgt = r [nr_idx] .height ;".!!.
so i modify it like this:
vl_mser_pix nr_val = 0 ;
vl_uint     nr_idx = 0 ;
r_idx = climb(r,   idx) ;
nr_idx = climb(r, n_idx) ;
int         hgt   = r [ r_idx] .height ;
int         n_hgt = r [nr_idx] .height ;

it works correctly in my project. and thanks to the vl_feat, my project is success now!!!!
