### PR TITLE
Fix the documentation for vl_ikm_get_centers.

### DIFF
--- a/vl/ikmeans.c
+++ b/vl/ikmeans.c
@@ -259,15 +259,15 @@ vl_ikm_get_max_niters (VlIKMFilt const* f)
   return f->max_niters ;
 }
 
-/** @brief Get maximum number of iterations
+/** @brief Get the assigned centers
  ** @param f IKM filter.
- ** @return maximum number of iterations.
+ ** @return centers the assigned centers.
  **/
 
 vl_ikmacc_t const *
 vl_ikm_get_centers (VlIKMFilt const* f)
 {
-  return f-> centers ;
+  return f->centers ;
 }
 
 /** @brief Set verbosity level


### PR DESCRIPTION
The function had the wrong documentation.
An unnecessary space was also removed.