### PR TITLE
Fixed the issue that the preset iteration number has not been used when warm starting SGD training

### DIFF
--- a/vl/svm.c
+++ b/vl/svm.c
@@ -2061,7 +2061,7 @@ void _vl_svm_sgd_train (VlSvm *self)
      are explicitly applied to the model and the bias.
   */
 
-  for (t = 0 ; 1 ; ++t) {
+  for (t = self->iteration; 1 ; ++t) {
 
     if (t % self->numData == 0) {
       /* once a new epoch is reached (all data have been visited),

--- a/vl/svm.c
+++ b/vl/svm.c
@@ -2099,7 +2099,7 @@ void _vl_svm_sgd_train (VlSvm *self)
     }
 
     /* call diagnostic occasionally */
-    if ((t + 1) % self->diagnosticFrequency == 0 || t + 1 == self->maxNumIterations) {
+    if ((t + 1) % self->diagnosticFrequency == 0 || t + 1 == (self->maxNumIterations + self->iteration)) {
 
       /* realize factor before computing statistics or completing training */
       for (k = 0 ; k < self->dimension ; ++k) self->model[k] *= factor ;
@@ -2123,7 +2123,7 @@ void _vl_svm_sgd_train (VlSvm *self)
       if (self->statistics.scoresVariation < self->epsilon) {
         self->statistics.status = VlSvmStatusConverged ;
       }
-      else if (t + 1 == self->maxNumIterations) {
+      else if (t + 1 == (self->maxNumIterations + self->iteration)) {
         self->statistics.status = VlSvmStatusMaxNumIterationsReached ;
       }
 


### PR DESCRIPTION
When warm starting an SGD training one should set an advanced iteration count for a softer continuation, but the iteration loop is always initialized with 0, neglecting the preset value.
