### PR TITLE
Update vl_argparse.m

### DIFF
--- a/toolbox/misc/vl_argparse.m
+++ b/toolbox/misc/vl_argparse.m
@@ -37,7 +37,7 @@ function [conf, args] = vl_argparse(conf, args, varargin)
 
 if ~isstruct(conf), error('CONF must be a structure') ; end
 
-if length(varargin) > 0, args = {args, varargin{:}} ; end
+if length(varargin) > 0, args = {args{:}, varargin{:}} ; end
 
 remainingArgs = {} ;
 names = fieldnames(conf) ;


### PR DESCRIPTION
When length(varargin) is > 0 we need to append varargin to the args and not treat args as a single cell