### PR TITLE
check HAS_CPUID before use of _vl_cpuid

### DIFF
--- a/vl/host.c
+++ b/vl/host.c
@@ -441,6 +441,7 @@ _vl_cpuid (vl_int32* info, int function)
 
 #endif
 
+#if defined(HAS_CPUID)
 void
 _vl_x86cpu_info_init (VlX86CpuInfo *self)
 {
@@ -463,6 +464,7 @@ _vl_x86cpu_info_init (VlX86CpuInfo *self)
     self->hasAVX   = info[2] & (1 << 28) ;
   }
 }
+#endif
 
 char *
 _vl_x86cpu_info_to_string_copy (VlX86CpuInfo const *self)


### PR DESCRIPTION
If `HAS_CPUID` is not defined then `_vl_cpuid` will result in an undefined reference error.

This issue was noticed and fixed in https://github.com/openMVG/openMVG/issues/488 and https://github.com/openMVG/openMVG/commit/cbc35f63293ea053a85916a45441143f2727d011 for vlfeat in OpenMVG, but it might be beneficial to include here.