### PR TITLE
pgm.c: fix pmg image max value

### DIFF
--- a/vl/pgm.c
+++ b/vl/pgm.c
@@ -233,7 +233,7 @@ vl_pgm_extract_head (FILE* f, VlPgmImage *im)
     return vl_set_last_error(VL_ERR_PGM_INV_META, "Invalid PGM meta information");
   }
 
-  if(! (max_value >= 65536)) {
+  if(max_value >= 65536) {
     return vl_set_last_error(VL_ERR_PGM_INV_META, "Invalid PGM meta information");
   }
 


### PR DESCRIPTION
The bugfix in a737296 fixed the wrong typo (the ! shouldn't have been
there in the first place)