### PR TITLE
Unbreak build with GCC 9.1.0 (OpenMP 4.0)

### DIFF
--- a/vl/kmeans.c
+++ b/vl/kmeans.c
@@ -669,7 +669,7 @@ VL_XCAT(_vl_kmeans_quantize_, SFX)
 #endif
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) \
+#pragma omp parallel \
             shared(self, distances, assignments, numData, distFn, data) \
             num_threads(vl_get_max_threads())
 #endif


### PR DESCRIPTION
```c
$ gcc9 -fopenmp -c vl/kmeans.c
In file included from vl/kmeans.h:21,
                 from vl/kmeans.c:363:
vl/kmeans.c: In function '_vl_kmeans_quantize_f':
vl/mathop.h:92:37: error: 'vl_infinity_d' not specified in enclosing 'parallel'
   92 | #define VL_INFINITY_D (vl_infinity_d.value)
      |                       ~~~~~~~~~~~~~~^~~~~~~
vl/kmeans.c:685:34: note: in expansion of macro 'VL_INFINITY_D'
  685 |       TYPE bestDistance = (TYPE) VL_INFINITY_D ;
      |                                  ^~~~~~~~~~~~~
In file included from vl/kmeans.c:1782:
vl/kmeans.c:672:9: error: enclosing 'parallel'
  672 | #pragma omp parallel default(none) \
      |         ^~~
In file included from vl/kmeans.c:1788:
vl/kmeans.c: In function '_vl_kmeans_quantize_d':
vl/kmeans.c:685:27: error: 'vl_infinity_d' not specified in enclosing 'parallel'
  685 |       TYPE bestDistance = (TYPE) VL_INFINITY_D ;
vl/kmeans.c:672:9: error: enclosing 'parallel'
  672 | #pragma omp parallel default(none) \
      |         ^~~
```
https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925853
