### PR TITLE
correct error for max_value in pgm

### DIFF
--- a/vl/pgm.c
+++ b/vl/pgm.c
@@ -233,7 +233,7 @@ vl_pgm_extract_head (FILE* f, VlPgmImage *im)
     return vl_set_last_error(VL_ERR_PGM_INV_META, "Invalid PGM meta information");
   }
 
-  if(! (max_value >= 65536)) {
+  if(max_value >= 65536) {
     return vl_set_last_error(VL_ERR_PGM_INV_META, "Invalid PGM meta information");
   }
 


### PR DESCRIPTION
There is a error in processing pgm format.  It doesn't work when  max_value < 65536 , perhaps  "max_value > 65536"  can be used instead.