### PR TITLE
Make: Reliably put user-provided CFLAGS/LDFLAGS at the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ endif
 VLDIR ?= .
 LIBTOOL ?= libtool
 
-STD_CLFAGS = $(CFLAGS)
+STD_CFLAGS = $(CFLAGS)
 STD_CFLAGS += -std=c99
 STD_CFLAGS += -Wall -Wextra
 STD_CFLAGS += -Wno-unused-function -Wno-long-long -Wno-variadic-macros

--- a/Makefile
+++ b/Makefile
@@ -150,14 +150,19 @@ endif
 VLDIR ?= .
 LIBTOOL ?= libtool
 
-STD_CFLAGS = $(CFLAGS)
-STD_CFLAGS += -std=c99
+STD_CFLAGS = -std=c99
 STD_CFLAGS += -Wall -Wextra
 STD_CFLAGS += -Wno-unused-function -Wno-long-long -Wno-variadic-macros
 STD_CFLAGS += $(if $(DEBUG), -DDEBUG -O0 -g, -DNDEBUG -O3)
 STD_CFLAGS += $(if $(PROFILE), -g)
+# User-provided CFLAGS to be put at the end of all compiler invocations so
+# that they can override our defaults.
+USER_CFLAGS = $(CFLAGS)
 
-STD_LDFLAGS = $(LDFLAGS)
+STD_LDFLAGS =
+# User-provided LDFLAGS to be put at the end of all linker invocations so
+# that they can override our defaults.
+USER_LDFLAGS = $(LDFLAGS)
 
 # Architecture specific ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -354,7 +359,9 @@ info:
 	$(call echo-var,COMPILER)
 	$(call echo-var,COMPILER_VER)
 	$(call echo-var,STD_CFLAGS)
+	$(call echo-var,USER_CFLAGS)
 	$(call echo-var,STD_LDFLAGS)
+	$(call echo-var,USER_LDFLAGS)
 	$(call echo-var,DISABLE_SSE2)
 	$(call echo-var,DISABLE_AVX)
 	$(call echo-var,DISABLE_THREADS)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@
 #   DEBUG [not defined] - If defined, turns on debugging symbols and
 #       turns off optimizations
 #
+#   ASSERTIONS [not defined] - If defined, turns on assertions
+#
 #   PROFILE [not defined] - If defined, turns on debugging symbols but
 #       does NOT turn off optimizations.
 #
@@ -153,7 +155,8 @@ LIBTOOL ?= libtool
 STD_CFLAGS = -std=c99
 STD_CFLAGS += -Wall -Wextra
 STD_CFLAGS += -Wno-unused-function -Wno-long-long -Wno-variadic-macros
-STD_CFLAGS += $(if $(DEBUG), -DDEBUG -O0 -g, -DNDEBUG -O3)
+STD_CFLAGS += $(if $(DEBUG), -DDEBUG -O0 -g, -O3)
+STD_CFLAGS += $(if $(ASSERTIONS), , -DNDEBUG)
 STD_CFLAGS += $(if $(PROFILE), -g)
 # User-provided CFLAGS to be put at the end of all compiler invocations so
 # that they can override our defaults.
@@ -352,6 +355,7 @@ info:
 	$(call echo-title,General settings)
 	$(call dump-var,deps)
 	$(call echo-var,PROFILE)
+	$(call echo-var,ASSERTIONS)
 	$(call echo-var,DEBUG)
 	$(call echo-var,VER)
 	$(call echo-var,ARCH)

--- a/make/bin.mak
+++ b/make/bin.mak
@@ -75,7 +75,7 @@ bin-all: $(dll-dir) $(bin_tgt)
 # also http://wiki.debian.org/ToolChain/DSOLinking
 
 $(BINDIR)/% : $(VLDIR)/src/%.c $(dll_tgt)
-	$(call C,CC) $(BIN_CFLAGS) "$<" $(BIN_LDFLAGS) -o "$(@)"
+	$(call C,CC) $(BIN_CFLAGS) $(USER_CFLAGS) "$<" $(BIN_LDFLAGS) $(USER_LDFLAGS) -o "$(@)"
 ifdef BIN_RELINK_OMP
 	make/macos_relink_omp.sh "$(@)"
 endif
@@ -85,7 +85,7 @@ arch_bins += $(BINDIR)/libomp.dylib
 endif
 
 $(BINDIR)/%.d : $(VLDIR)/src/%.c $(dll-dir)
-	$(call C,CC) $(BIN_CFLAGS) -M -MT  \
+	$(call C,CC) $(BIN_CFLAGS) $(USER_CFLAGS) -M -MT  \
 	       '$(BINDIR)/$* $(BINDIR)/$*.d' \
 	       "$<" -MF "$@"
 
@@ -102,7 +102,9 @@ bin-info:
 	$(call dump-var,bin_tgt)
 	$(call dump-var,bin_dep)
 	$(call echo-var,BIN_CFLAGS)
+	$(call echo-var,USER_CFLAGS)
 	$(call echo-var,BIN_LDFLAGS)
+	$(call echo-var,USER_LDLAGS)
 	@echo
 
 # Local variables:

--- a/make/dll.mak
+++ b/make/dll.mak
@@ -110,14 +110,14 @@ $(eval $(call gendir, dll, $(BINDIR) $(BINDIR)/objs))
 $(BINDIR)/objs/%.o : $(VLDIR)/vl/%.c $(dll-dir)
 	$(call C,CC)                                            \
 	     -c -o "$(@)"                                       \
-	     $(DLL_CFLAGS) "$(<)"
+	     $(DLL_CFLAGS) $(USER_CFLAGS) "$(<)"
 
 $(BINDIR)/objs/%.d : $(VLDIR)/vl/%.c $(dll-dir)
 	$(call C,CC)						\
 	     -MM						\
 	     -MF "$(@)"						\
 	     -MT '$(BINDIR)/objs/$*.o $(BINDIR)/objs/$*.d'      \
-	     $(DLL_CFLAGS) "$(<)"
+	     $(DLL_CFLAGS) $(USER_CFLAGS) "$(<)"
 
 $(BINDIR)/lib$(DLL_NAME).dylib : $(dll_obj)
 	$(call C,CC)						\
@@ -129,6 +129,7 @@ $(BINDIR)/lib$(DLL_NAME).dylib : $(dll_obj)
 	  -current_version $(VER)				\
 	  -isysroot $(SDKROOT)					\
 	  $(DLL_LDFLAGS)					\
+	  $(USER_CFLAGS)					\
 	  $(^)							\
 	  -o "$(@)"
 ifdef BIN_RELINK_OMP
@@ -139,6 +140,7 @@ $(BINDIR)/lib$(DLL_NAME).so : $(dll_obj)
 	$(call C,CC) -shared                                    \
 	    $(^)                                                \
 	    $(DLL_LDFLAGS)	                                \
+	    $(USER_LDFLAGS)	                                \
 	    -o "$(@)"
 
 dll-clean:
@@ -159,7 +161,9 @@ dll-info:
 	$(call echo-var,BINDIR)
 	$(call echo-var,DLL_NAME)
 	$(call echo-var,LINK_DLL_CFLAGS)
+	$(call echo-var,USER_CFLAGS)
 	$(call echo-var,LINK_DLL_LDFLAGS)
+	$(call echo-var,USER_LDFLAGS)
 	$(call echo-var,DLL_CFLAGS)
 	$(call echo-var,DLL_LDFLAGS)
 	$(call echo-var,DLL_SUFFIX)

--- a/make/dll.mak
+++ b/make/dll.mak
@@ -19,8 +19,8 @@ info: dll-info
 #                                                        Configuration
 # --------------------------------------------------------------------
 
-# LINK_DLL_CLFAGS and LINK_DLL_LDFLAGS are the compiler options needed
-# to link to the VLFeat DLL. DLL_CLFAGS and DLL_LDFLAGS the options to
+# LINK_DLL_CFLAGS and LINK_DLL_LDFLAGS are the compiler options needed
+# to link to the VLFeat DLL. DLL_CFLAGS and DLL_LDFLAGS the options to
 # build the DLL.
 
 DLL_NAME = vl

--- a/make/matlab.mak
+++ b/make/matlab.mak
@@ -109,14 +109,14 @@ endif
 #
 # where
 #
-# * MEX_CLFAGS are standard compiler flags such as -I (include path).
+# * MEX_CFLAGS are standard compiler flags such as -I (include path).
 # * MEX_LDFLAGS are standard linker flags such as -L (library path)
 #   and -l (link library)
 # * MEX_FLAGS are other MEX flags such as -v (verbose). This variable
 #   is also used to contain overrides for the variables used
 #   internally by MEX.
 #
-# The variables STD_CLFAGS and STD_LDFLAGS contain settings which are
+# The variables STD_CFLAGS and STD_LDFLAGS contain settings which are
 # specific to one complier (e.g. GCC or clang). To pass these to MEX,
 # the following is appended to MEX_FLAGS, and ultimately to the MEX
 # command line:
@@ -124,13 +124,13 @@ endif
 #   CFLAGS='$$CFLAGS $(STD_CFLAGS)'
 #   LDFLAGS='$$LDFLAGS $(STD_LDFLAGS)'
 #
-# This causes MEX to append $(STD_CLFAGS) and $(STD_LDFLAGS) to its
+# This causes MEX to append $(STD_CFLAGS) and $(STD_LDFLAGS) to its
 # default settings.
 #
 # While this usually achieves the desired effects, some versions of
 # MATLAB may not be compatible with certain compilers (e.g. MATLAB
 # 2013a and Xcode 5.0 and Mac OS X 10.9). Fixing this requires
-# changing CLFAGS and LDFLAGS completely (i.e.  not just appending to
+# changing CFLAGS and LDFLAGS completely (i.e.  not just appending to
 # their default values).
 
 MEX_ARCH = $(ARCH)


### PR DESCRIPTION
Otherwise builds cannot override compiler flags set by default.

See commit message for details.

## TODO

* [ ] Based on top of #191 and #192, merge those first.