### PR TITLE
docs: vl_covdet_set_max_num_orientations() does not reset

### DIFF
--- a/vl/covdet.c
+++ b/vl/covdet.c
@@ -3317,8 +3317,6 @@ vl_covdet_set_base_scale (VlCovDet * self, double s)
 /** @brief Set the max number of orientations
  ** @param self object.
  ** @param m the max number of orientations.
- **
- ** Calling this function resets the detector.
  **/
 void
 vl_covdet_set_max_num_orientations (VlCovDet * self, vl_size m)


### PR DESCRIPTION
The docs claim a reset, but no reset is done in the function.