### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ ship with pre-built GNU Octave MEX files. To compile them use
     > cd <vlfeat directory>
     > make MKOCTFILE=<path to the mkoctfile program>
 
+## Building vlfeat - Using vcpkg
+
+You can download and install vlfeat using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install vlfeat
+
+The vlfeat port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+    
 # Changes
 
 - **0.9.21** Maintenance release. Bugfixes.


### PR DESCRIPTION
vlfeat is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for vlfeat and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build vlfeat, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/vlfeat/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)
